### PR TITLE
remove unnecessary "super" keyword

### DIFF
--- a/src/util/Requests/APIError.js
+++ b/src/util/Requests/APIError.js
@@ -1,7 +1,6 @@
 class APIError {
 
     constructor(message, endpoint, method, code, data, options) {
-        super(message);
         this.name = "APIError";
         this.error = "APIError";
         this.endpoint = endpoint;


### PR DESCRIPTION
APIError doesn't extend a class, so the presence of the "super" keyword causes an error.